### PR TITLE
Validate whether a file defined a label multiple times during assembly

### DIFF
--- a/mvn-assembler/Cargo.toml
+++ b/mvn-assembler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mvn-assembler"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mvn-assembler/src/processor/validator.rs
+++ b/mvn-assembler/src/processor/validator.rs
@@ -17,10 +17,24 @@ pub fn validate<'a, 'b>(
     Ok(())
 }
 
+struct ProgramValidator<'a, 'b> {
+    program: &'a AddressedProgram<'b>,
+    label_map: &'a LabelMap<'b>,
+}
+
 struct LineValidator<'a, 'b> {
     line: &'a Line<'b>,
     address: &'a Address,
     label_map: &'a LabelMap<'b>,
+}
+
+/* Every validator function's name should
+ * answer the question: "Does the program
+ * contain {name}?"
+ */
+
+impl <'b> ProgramValidator<'_, 'b> {
+
 }
 
 impl<'b> LineValidator<'_, 'b> {
@@ -33,10 +47,6 @@ impl<'b> LineValidator<'_, 'b> {
         Ok(())
     }
 
-    /* Every validator function's name should
-     * answer the question: "Does the program
-     * contain {name}?"
-     */
 
     fn numeric_operand_on_import_export(&self) -> ValidatorResult<'b> {
         match &self.line.operation.instruction.value {
@@ -129,6 +139,15 @@ impl<'b> LineValidator<'_, 'b> {
                 }
             },
             _ => Ok(()),
+        }
+    }
+}
+
+impl<'a, 'b> ProgramValidator<'a, 'b> {
+    fn new(program: &'a AddressedProgram<'b>, label_map: &'a LabelMap<'b>) -> Self {
+        Self {
+            program,
+            label_map,
         }
     }
 }

--- a/mvn-utils/src/types.rs
+++ b/mvn-utils/src/types.rs
@@ -64,3 +64,12 @@ impl<T: fmt::UpperHex> fmt::UpperHex for Token<T> {
         write!(f, "{:X}", &self.value)
     }
 }
+
+impl <T: Clone> Clone for Token<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            position: self.position,
+        }
+    }
+}

--- a/mvn-utils/src/types.rs
+++ b/mvn-utils/src/types.rs
@@ -65,7 +65,7 @@ impl<T: fmt::UpperHex> fmt::UpperHex for Token<T> {
     }
 }
 
-impl <T: Clone> Clone for Token<T> {
+impl<T: Clone> Clone for Token<T> {
     fn clone(&self) -> Self {
         Self {
             value: self.value.clone(),


### PR DESCRIPTION
Fixes #24.

Current behaviour, as described in the issue, is
```shell
$ cargo run --bin mvn-assembler -- <<EOF
FOO LV /0
FOO LV /5
BAR LD FOO
EOF
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/mvn-assembler`
0000 3000
0002 3005
0004 8002
```

This PR changes this behaviour to
```shell
$ cargo run --bin mvn-assembler -- <<EOF
FOO LV /0
FOO LV /5
BAR LD FOO
EOF
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/mvn-assembler`
error: error while handling input file
  |
2 | FOO LV /5
  |  ^ label was already defined
  |
```